### PR TITLE
ci: use GitHub-hosted ubuntu-latest runners

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   stale:
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v10
         with:


### PR DESCRIPTION
## Summary
Switches self-hosted Linux CI jobs to GitHub-hosted `ubuntu-latest`.

## Why
GitHub-hosted standard runners are **free and unlimited on public repos**. Moving CI off the home-lab self-hosted runners:
- frees my servers from CI load,
- runs PR code in throwaway isolated VMs (removes the fork-PR attack surface entirely),
- costs $0 on public repos.

The earlier self-hosted fork-guard `if:` is removed (no longer needed on hosted runners). Any macOS/Windows self-hosted jobs (desktop builds) are left unchanged.
